### PR TITLE
Add name extraction and simple API

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,31 @@
+import os
+
+from flask import Flask, request, jsonify
+from schematics.models import Model
+from schematics.types import StringType
+from schematics.types.compound import ListType, ModelType
+
+from name_extractor import extract_person_names
+
+DEVELOPMENT_MODE = os.environ.get('DEVELOP') == 'true'
+
+app = Flask(__name__)
+
+
+class RequestData(Model):
+    text = StringType(required=True)
+
+
+@app.route('/extract-names/', methods=['POST'])
+def extract_names():
+    request_data = RequestData(request.json)
+    request_data.validate()
+
+    names = [{"name": name, "gender": ""}
+             for name in extract_person_names(request_data.text)]
+
+    return jsonify({"names": names})
+
+
+if __name__ == '__main__':
+    app.run(debug=DEVELOPMENT_MODE)

--- a/name_extractor.py
+++ b/name_extractor.py
@@ -1,0 +1,39 @@
+import io
+
+import nltk
+
+pos_tagger = nltk.tag.PerceptronTagger()
+
+
+def extract_person_names(text):
+    sentences = nltk.sent_tokenize(text)
+    tokenized_sentences = [nltk.word_tokenize(sentence) for sentence in sentences]
+    tagged_sentences = [pos_tagger.tag(sentence) for sentence in tokenized_sentences]
+    chunked_sentences = nltk.ne_chunk_sents(tagged_sentences)
+
+    return set(_flat_map(extract_person_names_from_tree(tree)
+                         for tree in chunked_sentences))
+
+
+def extract_person_names_from_tree(tree):
+    names = []
+
+    if hasattr(tree, 'label') and tree.label:
+        if tree.label() == 'PERSON':
+            names.append(' '.join([child[0] for child in tree]))
+        else:
+            for child in tree:
+                names.extend(extract_person_names_from_tree(child))
+
+    return names
+
+
+def _flat_map(list_of_lists):
+    return [item for sublist in list_of_lists for item in sublist]
+
+
+if __name__ == '__main__':
+    with io.open('sample.txt', 'r', encoding='utf-8') as f:
+        sample = f.read()
+
+    print extract_person_names(sample)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+nltk
+numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+flask
 nltk
 numpy
+schematics

--- a/sample.txt
+++ b/sample.txt
@@ -1,0 +1,47 @@
+WASHINGTON — An epic Washington political battle took shape on Sunday after the death of Justice Antonin Scalia as Senate Republicans dug in and refused to act on any Supreme Court nomination by President Obama. But the White House vowed to name a nominee within weeks.
+
+Two senators seeking the Republican presidential nomination, Ted Cruz of Texas and Marco Rubio of Florida, both said unequivocally that the Republican-controlled Senate should ignore any nomination sent by Mr. Obama to Capitol Hill.
+
+“The president can nominate whoever he wants, but the Senate is not going to act, and that’s pretty clear,” Mr. Rubio said on “Fox News Sunday.” “So, we can keep debating it but we’re not moving forward on it, period.”
+
+In an interview on ABC’s “This Week,” Mr. Cruz, a member of the Senate Judiciary Committee, said: “Let the election decide it. If the Democrats want to replace this nominee, they need to win the election.”
+
+Their comments followed declarations by Senator Mitch McConnell, a Kentucky Republican and the majority leader, that President Obama should not try to fill the vacancy left by Justice Scalia, who died on Saturday in Texas, given that less than a year remains in the president’s second term.
+
+That view is backed by Senator Charles E. Grassley, the Iowa Republican who is chairman of the Judiciary Committee, which would consider any nominee. The stance puts Senate Republicans in the politically charged position of defying the president on a crucial court opening amid the heat of the presidential campaign — and while also trying to hold on to their majority in the Senate.
+
+Democrats immediately sought to pressure Republicans, saying that a refusal to even consider a nominee would amount to an outrageous act of obstructionism — a charge that has been leveled at Mr. McConnell in the past with some success. Democrats predicted that a backlash from the public, particularly in the swing states where Republicans need to win to hold on to control of the Senate, could eventually prompt reconsideration by Mr. McConnell.
+
+“I think there is at least a 50-50 chance that pressure from the Republican Senate caucus will force McConnell to reverse himself and at least hold hearings and a vote,” said Senator Chuck Schumer of New York, the No. 3 Democrat in the Senate and a senior member of the Judiciary Committee.
+
+In choosing a nominee, Mr. Obama faces his own complicated calculus: He could pick a liberal version of Justice Scalia, which would fire up Democrats but would virtually assure that Republicans would block the nomination in the Senate. Or he could choose a moderate — someone who came up as a prosecutor or a corporate litigator, with little record on culture-war issues — which could increase pressure on Republicans to allow a vote.
+
+But that could pose other problems. If Mr. Obama passes up the opportunity to put forward a progressive in favor of someone who represented corporations, it could provoke blowback from the left. The danger is not just reducing potential voter enthusiasm from Democrats but roiling the Democratic presidential primary.
+
+The two Democratic candidates will have to take a stand on whomever the president nominates, and Senator Bernie Sanders of Vermont is challenging Hillary Clinton from the left and making the power of the corporate establishment an issue.
+
+It was not yet clear which way the president was leaning. But some former White House officials said they would advocate a nominee with a proven record of support in Congress as a way of laying bare the purely political nature of the Republican opposition.
+
+“There will be many opinions on this, and a lot of good candidates,” said David Axelrod, a former senior adviser to Mr. Obama. “But I would favor sitting appellate judges like Srinivasan or Jane Kelly from the Eighth Circuit, who have cleared the Senate unanimously.”
+
+Mr. Axelrod was referring to Sri Srinivasan, an Indian-American jurist whom Mr. Obama named to the United States Court of Appeals and who was confirmed by a vote of 97 to 0 by the Senate in May 2013. Jane Kelly, a former federal public defender in Iowa who was in Mr. Obama’s class at Harvard Law School, was named to the Court of Appeals by him in 2013. Like Judge Srinivasan, she was confirmed unanimously — in her case, 96 to 0.
+
+Any nominee for the Supreme Court from Mr. Obama would, if blocked by the Senate, would become a leading candidate for a Supreme Court nomination from a future Democratic president. Still, Mr. Axelrod said he did not expect Mr. Obama to consult either Mrs. or Senator Sanders on his choice.
+
+“I don’t believe the next president would be bound by this appointment, nor do I feel he needs to consult with the candidates,” he said.
+
+The shock of Justice Scalia’s death and the battle over whether to proceed with a confirmation, which will likely last months, threatened to upend Mr. McConnell’s careful plans to show that the Senate was working again after years of dysfunction. Republicans were eager for a relatively calm year leading into the election, but Mr. Scalia’s death ended those hopes.
+
+Democrats said that if Mr. McConnell persisted in trying to block a nomination, he should anticipate little cooperation from them moving forward.
+
+“If McConnell stonewalls, we will empty the arsenal,” said one top Democratic official, who requested anonymity to discuss party strategy. “We will make sure this is seen as the radical, unprecedented act of obstruction that it is.”
+
+Democrats said that they would welcome the opportunity to confirm a justice who would reshape the ideological makeup of the court with so many crucial decisions looming. But they said a fight over Republicans dismissing a nominee without a hearing or a vote played to their political advantage and would motivate voters both in the presidential contest and the crucial Senate races in states such as Illinois, Wisconsin, Pennsylvania, Ohio, New Hampshire and elsewhere.
+
+Republicans said that the fight would energize their voters as well and that they would face a conservative revolt if they did proceed with a nominee, allowing Mr. Obama a late-term victory in potentially reshaping the court for years.
+
+For Mr. Obama, the prospect of a battle for the ideological soul of the nation’s highest court drastically transforms a final year that had been shaping up as an extended exercise in legacy-building.
+
+Mr. Obama was informed of Justice Scalia’s death while on a golf course in Rancho Mirage, Calif., where he is spending a leisurely long weekend with childhood friends from Hawaii. His six-day swing to the West Coast had been replete with images of a president in his last lap, defending his record, raising money for other Democratic candidates, and announcing largely symbolic steps to secure his achievements.
+
+Last week, Mr. Obama visited Springfield, Ill., and addressed the state assembly not far from where he announced his candidacy in February 2007. At fund-raisers in Silicon Valley and Los Angeles, he spoke of his desire to remain politically relevant after he leaves office and lamented the fact that voters appear so angry, even though, he insisted, “the country is indisputably, demonstrably better off than when I took office in just about every measure.”


### PR DESCRIPTION
This PR implements simple named-entity-extraction, based on [this code snippet](https://gist.github.com/onyxfish/322906), using NLTK. It also implements a simple REST API route for passing in text and getting back the names of people in the text.

The code snippet is modified for reusability, applicability, and performance. In particular:
- The main text-processing code is moved into a reusable function
- The part-of-speech tagger is loaded ahead of time into memory, so that its loading doesn't slow down the processing. See [this StackOverflow question](http://stackoverflow.com/questions/11610076/slow-performance-of-pos-tagging-can-i-do-some-kind-of-pre-warming) for more details.
- It is also modified to look for PERSON entities, instead of collecting all types of named entities.

The API is straightforward. It receives JSON like:

```
{"text": " ... "}
```

It returns JSON like:

```
{"names": [{"name": "Clara", "gender": ""}]}
```

The gender part is a placeholder for a future improvement in which we will incorporate gender prediction.
